### PR TITLE
fix: nixpkgs-bump repair + robust modem daemon (no-hang discovery)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1771796463,
-        "narHash": "sha256-9bCDuUzpwJXcHMQYMS1yNuzYMmKO/CCwCexpjWOl62I=",
+        "lastModified": 1780099841,
+        "narHash": "sha256-EVZd2RsbpreRUDSi9rBwPY+ZxoyMaiEBbZxxhljbaS4=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3d3de3313e263e04894f284ac18177bd26169bad",
+        "rev": "0532eb17955225173906d671fb36306bdeb1e2dc",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1772216104,
-        "narHash": "sha256-1TnGN26vnCEQk5m4AavJZxGZTb/6aZyphemRPRwFUfs=",
+        "lastModified": 1780308674,
+        "narHash": "sha256-68H7z1MLdPCtWE4qetwTiMdtztZ7AwEKM9yS9Q+wZa8=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "dbe5112de965bbbbff9f0729a9789c20a65ab047",
+        "rev": "11918137828af784150f7a2da52cf50abf34f501",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772525000,
-        "narHash": "sha256-M7kpjimt0jdEQzmin6ptszf8ev7TVzibyZNSLaLquMM=",
+        "lastModified": 1780336545,
+        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "72b1d820cb0149b40a35aa077b4b6d60cd1b23c3",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771858127,
-        "narHash": "sha256-Gtre9YoYl3n25tJH2AoSdjuwcqij5CPxL3U3xysYD08=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "49bbbfc218bf3856dfa631cead3b052d78248b83",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771988922,
-        "narHash": "sha256-Fc6FHXtfEkLtuVJzd0B6tFYMhmcPLuxr90rWfb/2jtQ=",
+        "lastModified": 1780284119,
+        "narHash": "sha256-y2wR4Mk6D/N1ID4FZa2oUMStCUxyIoRzmgOOpLzoWmo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f4443dc3f0b6c5e6b77d923156943ce816d1fcb9",
+        "rev": "51390d0bfca0a68a8c337d215a4bbeddc2ca616e",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772495394,
-        "narHash": "sha256-hmIvE/slLKEFKNEJz27IZ8BKlAaZDcjIHmkZ7GCEjfw=",
+        "lastModified": 1777944972,
+        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1d9b98a29a45abe9c4d3174bd36de9f28755e3ff",
+        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -182,8 +182,6 @@
                 age
 
                 # Frontend development
-                nodejs_20
-                nodePackages.npm
                 oxlint
 
                 # Rust development

--- a/nixos-config/modules/sms-daemon.nix
+++ b/nixos-config/modules/sms-daemon.nix
@@ -182,6 +182,9 @@ in
           # RestartPreventExitStatus = "1";  # Only prevent restart on config errors
           StartLimitIntervalSec = "300";
           StartLimitBurst = "5";
+          # preStart waits up to max_wait=180s for USB enumeration to settle;
+          # raise the start timeout above that so systemd doesn't abort it.
+          TimeoutStartSec = "300s";
 
           # Working directory
           WorkingDirectory = "/var/lib/sms-daemon";
@@ -363,11 +366,35 @@ in
         echo "ModemManager mode: $modem_count modem(s) detected"
         logger -t sms-daemon "Starting SMS daemon (D-Bus mode: $modem_count modems)"
       '' else ''
-        # AT command mode: check for USB serial ports
-        usb_ports=$(ls /dev/ttyUSB* 2>/dev/null | wc -l || echo "0")
-        at_ports=$((usb_ports / 4))  # Each modem has 4 ports
-        echo "AT command mode: $at_ports modem(s) detected ($usb_ports USB ports)"
-        logger -t sms-daemon "Starting SMS daemon (AT mode: $at_ports modems)"
+        # AT command mode: wait for USB enumeration to settle before starting.
+        #
+        # The daemon builds its modem cache ONCE at startup. On boot (or after a
+        # USB topology change) the kernel keeps enumerating ttyUSB ports for tens
+        # of seconds; starting before that finishes freezes the cache at a low
+        # count (observed: 10 instead of 60). We poll until the port count stays
+        # unchanged for several consecutive checks, with a hard timeout fallback.
+        poll_interval=5      # seconds between polls
+        settle_target=4      # consecutive stable polls required (~20s steady)
+        max_wait=180         # hard cap so boot never hangs
+        last=-1
+        stable=0
+        elapsed=0
+        while [ "$elapsed" -lt "$max_wait" ]; do
+          count=$(ls /dev/ttyUSB* 2>/dev/null | wc -l)
+          if [ "$count" -gt 0 ] && [ "$count" -eq "$last" ]; then
+            stable=$((stable + 1))
+          else
+            stable=0
+          fi
+          last=$count
+          [ "$stable" -ge "$settle_target" ] && break
+          sleep "$poll_interval"
+          elapsed=$((elapsed + poll_interval))
+        done
+        usb_ports=$last
+        at_ports=$((usb_ports / 4))  # Each modem exposes ~4 ports
+        echo "AT command mode: USB settled at $usb_ports ports ($at_ports modems) after ''${elapsed}s"
+        logger -t sms-daemon "Starting SMS daemon (AT mode: $at_ports modems, USB settled in ''${elapsed}s)"
       '';
 
       # Post-stop cleanup
@@ -383,6 +410,14 @@ in
     # ModemManager: only enable in D-Bus mode
     # In AT command mode, ModemManager is disabled for better performance
     networking.modemmanager.enable = cfg.useDBus;
+
+    # Allow the daemon (member of the dialout group) to issue USBDEVFS_RESET on the
+    # Quectel modem USB device nodes (/dev/bus/usb/BBB/DDD). This backs the active
+    # USB-reset recovery for wedged modems. Scoped to vendor 2c7c (Quectel) so we
+    # don't broaden write access to unrelated USB devices.
+    services.udev.extraRules = mkIf (!cfg.useDBus) ''
+      SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="2c7c", GROUP="dialout", MODE="0664"
+    '';
 
   };
 }

--- a/nixos-config/orange-pi/configuration.nix
+++ b/nixos-config/orange-pi/configuration.nix
@@ -231,8 +231,8 @@
   # =============================================================================
 
   boot = {
-    # Use hardened kernel packages for enhanced security
-    kernelPackages = lib.mkForce pkgs.linuxPackages_hardened;
+    # hardened kernel removed upstream (unmaintained); use latest mainline
+    kernelPackages = lib.mkForce pkgs.linuxPackages_latest;
 
     # Load watchdog kernel module (Orange Pi usually uses sunxi_wdt)
     kernelModules = [ "sunxi_wdt" ]; # Allwinner watchdog for Orange Pi

--- a/nixos-config/orange-pi/configuration.nix
+++ b/nixos-config/orange-pi/configuration.nix
@@ -252,6 +252,7 @@
       # USB optimization for 100 modems
       "usbcore.usbfs_memory_mb=1024" # Increase USB buffer (default 16MB, 1GB for 100 modems)
       "usbcore.autosuspend=-1" # Disable USB autosuspend
+      "usbcore.old_scheme_first=1" # Try legacy enumeration handshake first (helps marginal modems)
       "xhci_hcd.quirks=270336" # USB controller quirk for stability (from dotfiles)
       "log_buf_len=4M" # Increase kernel message buffer
       "elevator=noop" # Optimize for throughput

--- a/orange-pi-daemon/Cargo.toml
+++ b/orange-pi-daemon/Cargo.toml
@@ -47,7 +47,8 @@ rusqlite = { version = "0.30", features = ["bundled", "chrono"] }
 
 # Terminal I/O for direct AT command communication (bypasses ModemManager)
 # Using nix for termios - no libudev dependency
-nix = { version = "0.29", features = ["term", "fs"] }
+# "ioctl" provides the ioctl_none! macro used for USBDEVFS_RESET (modem USB reset)
+nix = { version = "0.29", features = ["term", "fs", "ioctl"] }
 
 [profile.release]
 opt-level = 3

--- a/orange-pi-daemon/scripts/slim-modem-usbcfg.sh
+++ b/orange-pi-daemon/scripts/slim-modem-usbcfg.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Slim every Quectel EC20 modem's USB composition from the default 5 interfaces
+# (DIAG/NMEA/AT/MODEM/QMI) down to AT+MODEM (3 interfaces, 2 ttyUSB ports).
+#
+# Why: each unused interface consumes USB endpoints + periodic bandwidth. On the
+# xHCI controllers this exhausts host-controller resources (error -12) and caps how
+# many modems enumerate. Slimming lets more modems fit per controller/hub.
+#
+# Safe by construction:
+#   - skips modems already slimmed (bNumInterfaces != 5)
+#   - only resets a modem if it ACCEPTED the usbcfg change (returned OK)
+#   - processes in chunks with pauses to avoid a mass re-enumeration storm
+#
+# Run on the Orange Pi as root. Stops the daemon for the duration, restarts after.
+set -u
+
+USBCFG='AT+QCFG="usbcfg",0x2C7C,0x0125,0,0,1,1,0,0,0'   # diag=0 nmea=0 at=1 modem=1 rmnet=0
+CHUNK=12          # modems per chunk
+CHUNK_PAUSE=15    # seconds between chunks (let each chunk re-enumerate)
+SETTLE=60         # final wait before restarting the daemon
+
+# Resolve the daemon's bin dir (has at_debug) from the running process.
+BIN=$(dirname "$(readlink -f /proc/"$(pgrep -x sms-daemon | head -1)"/exe 2>/dev/null)" 2>/dev/null)
+if [ -z "$BIN" ] || [ ! -x "$BIN/at_debug" ]; then
+  echo "FATAL: could not locate at_debug (BIN='$BIN')"; exit 1
+fi
+echo "using at_debug at $BIN/at_debug"
+
+# Find the AT port for a USB device dir: first ttyUSB (ascending) that answers AT.
+at_port_for_dev() {
+  local dev="$1" tn dp
+  for n in $(for t in /sys/class/tty/ttyUSB*; do
+                tn=$(basename "$t"); dp=$(readlink -f "$t/device")
+                case "$dp" in */"$dev"/*) echo "${tn#ttyUSB}";; esac
+              done | sort -n); do
+    if "$BIN/at_debug" "/dev/ttyUSB$n" "AT" 2>/dev/null | grep -q "OK"; then
+      echo "/dev/ttyUSB$n"; return 0
+    fi
+  done
+  return 1
+}
+
+echo "stopping daemon..."
+systemctl stop sms-daemon; sleep 2
+
+# Collect target modems (5-interface Quectel only).
+TARGETS=()
+for d in /sys/bus/usb/devices/*/; do
+  [ "$(cat "$d/idVendor" 2>/dev/null)" = "2c7c" ] || continue
+  [ "$(cat "$d/bNumInterfaces" 2>/dev/null)" = "5" ] || continue
+  TARGETS+=("$(basename "$d")")
+done
+echo "found ${#TARGETS[@]} modems to slim (5-interface)"
+
+done_count=0; skip_count=0; i=0
+for dev in "${TARGETS[@]}"; do
+  port=$(at_port_for_dev "$dev") || { echo "  $dev: no AT port, skip"; skip_count=$((skip_count+1)); continue; }
+  resp=$("$BIN/at_debug" "$port" "$USBCFG" 2>&1)
+  if echo "$resp" | grep -q "OK"; then
+    "$BIN/at_debug" "$port" "AT+CFUN=1,1" >/dev/null 2>&1
+    echo "  $dev ($port): slimmed + reset"
+    done_count=$((done_count+1))
+  else
+    echo "  $dev ($port): usbcfg REJECTED, not reset"
+    skip_count=$((skip_count+1))
+  fi
+  i=$((i+1))
+  if [ $((i % CHUNK)) -eq 0 ]; then echo "  -- chunk done, pausing ${CHUNK_PAUSE}s --"; sleep "$CHUNK_PAUSE"; fi
+done
+
+echo "slimmed=$done_count skipped=$skip_count; waiting ${SETTLE}s for re-enumeration..."
+sleep "$SETTLE"
+
+echo "restarting daemon..."
+systemctl reset-failed sms-daemon 2>/dev/null
+systemctl start sms-daemon
+sleep 2
+systemctl is-active sms-daemon

--- a/orange-pi-daemon/src/at_modem.rs
+++ b/orange-pi-daemon/src/at_modem.rs
@@ -11,10 +11,16 @@ use nix::sys::termios::{self, BaudRate, SetArg};
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
+
+// USBDEVFS_RESET = _IO('U', 20): re-enumerates a USB device via its usbfs node.
+// Equivalent to what `usbreset` does — recovers a wedged modem at the USB level.
+nix::ioctl_none!(usbdevfs_reset, b'U', 20);
 
 /// SMS message from AT command interface
 #[derive(Debug, Clone)]
@@ -104,12 +110,10 @@ impl AtModemManager {
 
     /// Discover all Quectel EC20 AT command ports
     /// EC20 uses ttyUSB2 for AT commands (every 4th port starting at 2)
-    pub async fn discover_modems(&self) -> Result<Vec<String>> {
-        let mut ports = Vec::new();
-        let mut probe_failed_count = 0;
-
-        // Scan /dev/ttyUSB* for AT command ports without an arbitrary upper bound
-        // EC20 pattern: ttyUSB2, ttyUSB6, ttyUSB10, ... (every 4th, offset 2)
+    /// Enumerate candidate AT-command ports present in /dev.
+    /// EC20/EC25 pattern: each modem exposes 4 ttyUSB ports and the AT port is the
+    /// 3rd (offset 2), so AT ports are ttyUSB2, ttyUSB6, ttyUSB10, … (num % 4 == 2).
+    pub fn candidate_at_ports() -> Result<Vec<String>> {
         let mut at_ports: Vec<String> = fs::read_dir("/dev")
             .map_err(|e| anyhow!("Failed to read /dev for modem discovery: {}", e))?
             .filter_map(|entry| entry.ok())
@@ -119,11 +123,7 @@ impl AtModemManager {
                 if !name.starts_with("ttyUSB") {
                     return None;
                 }
-
-                let num_str = name.trim_start_matches("ttyUSB");
-                let num = num_str.parse::<u32>().ok()?;
-
-                // EC20 AT ports are every 4th port starting at 2
+                let num = name.trim_start_matches("ttyUSB").parse::<u32>().ok()?;
                 if num >= 2 && num % 4 == 2 {
                     Some(format!("/dev/ttyUSB{}", num))
                 } else {
@@ -131,8 +131,16 @@ impl AtModemManager {
                 }
             })
             .collect();
-
         at_ports.sort();
+        Ok(at_ports)
+    }
+
+    /// Discover all Quectel AT command ports that currently respond to AT.
+    pub async fn discover_modems(&self) -> Result<Vec<String>> {
+        let mut ports = Vec::new();
+        let mut probe_failed_count = 0;
+
+        let at_ports = Self::candidate_at_ports()?;
         let existing_count = at_ports.len();
 
         for port_path in at_ports {
@@ -184,7 +192,7 @@ impl AtModemManager {
     }
 
     /// Quick probe to check if port responds to AT command
-    async fn probe_port(&self, port: &str) -> bool {
+    pub async fn probe_port(&self, port: &str) -> bool {
         match self
             .send_at_command(port, "AT", Duration::from_millis(500))
             .await
@@ -194,8 +202,89 @@ impl AtModemManager {
         }
     }
 
+    /// Actively USB-reset the modem backing `port`, then wait for it to re-enumerate
+    /// and confirm it answers AT again. Recovers a wedged modem whose ttyUSB exists
+    /// but stopped responding. Returns Ok(true) if the modem answers AT after reset.
+    ///
+    /// Requires write access to the modem's usbfs node (/dev/bus/usb/BBB/DDD); on the
+    /// Orange Pi this is granted to the `dialout` group via a udev rule.
+    pub async fn reset_usb_port(&self, port: &str) -> Result<bool> {
+        let node = Self::usbfs_node_for_port(port)?;
+        info!("🔌 USB-resetting {} via {}", port, node.display());
+
+        let node_for_blocking = node.clone();
+        tokio::task::spawn_blocking(move || Self::reset_usb_sync(&node_for_blocking)).await??;
+
+        // The device disappears and re-enumerates; the kernel rebuilds the same
+        // ttyUSB node within a few seconds. Poll AT until it answers or we give up.
+        for attempt in 0..10 {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            if Path::new(port).exists() && self.probe_port(port).await {
+                debug!("✅ {} answered AT {}s after reset", port, attempt + 1);
+                return Ok(true);
+            }
+        }
+        warn!("⚠️  {} did not recover within 10s after USB reset", port);
+        Ok(false)
+    }
+
+    /// Issue the USBDEVFS_RESET ioctl on a usbfs node (blocking).
+    fn reset_usb_sync(node: &Path) -> Result<()> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(node)
+            .map_err(|e| anyhow!("Failed to open usbfs node {}: {}", node.display(), e))?;
+        // SAFETY: fd is a valid open usbfs device node; USBDEVFS_RESET takes no argument.
+        unsafe {
+            usbdevfs_reset(file.as_raw_fd())
+                .map_err(|e| anyhow!("USBDEVFS_RESET on {} failed: {}", node.display(), e))?;
+        }
+        Ok(())
+    }
+
+    /// Resolve a /dev/ttyUSBN port to its usbfs device node (/dev/bus/usb/BBB/DDD)
+    /// by walking up the sysfs device tree to the USB device that owns the interface.
+    fn usbfs_node_for_port(port: &str) -> Result<PathBuf> {
+        let dev_name = port
+            .strip_prefix("/dev/")
+            .ok_or_else(|| anyhow!("Unexpected port path: {}", port))?;
+        let device_link = format!("/sys/class/tty/{}/device", dev_name);
+        let mut dir = fs::canonicalize(&device_link)
+            .map_err(|e| anyhow!("Cannot resolve sysfs device for {}: {}", port, e))?;
+
+        // The tty hangs off a USB *interface* (e.g. 3-1.3.2.6:1.2). Walk up until we
+        // reach the USB *device* dir, which carries busnum/devnum.
+        loop {
+            if dir.join("busnum").is_file() && dir.join("devnum").is_file() {
+                let busnum = Self::read_sysfs_u8(&dir.join("busnum"))?;
+                let devnum = Self::read_sysfs_u8(&dir.join("devnum"))?;
+                return Ok(PathBuf::from(Self::usbfs_node_path(busnum, devnum)));
+            }
+            match dir.parent() {
+                Some(parent) if parent.starts_with("/sys") && parent != dir => {
+                    dir = parent.to_path_buf();
+                }
+                _ => return Err(anyhow!("No USB device (busnum/devnum) found above {}", port)),
+            }
+        }
+    }
+
+    /// Format the usbfs node path for a given bus/device number.
+    fn usbfs_node_path(busnum: u8, devnum: u8) -> String {
+        format!("/dev/bus/usb/{:03}/{:03}", busnum, devnum)
+    }
+
+    fn read_sysfs_u8(path: &Path) -> Result<u8> {
+        let raw = fs::read_to_string(path)
+            .map_err(|e| anyhow!("read {} failed: {}", path.display(), e))?;
+        raw.trim()
+            .parse::<u8>()
+            .map_err(|e| anyhow!("parse {} ('{}') failed: {}", path.display(), raw.trim(), e))
+    }
+
     /// Initialize IMS settings on modem
-    async fn init_ims(&self, port: &str) -> Result<()> {
+    pub async fn init_ims(&self, port: &str) -> Result<()> {
         // Enable IMS (IP Multimedia Subsystem)
         match self
             .send_at_command(port, "AT+QCFG=\"ims\",1", Duration::from_millis(1000))
@@ -1920,6 +2009,19 @@ mod tests {
         let bytes = vec![0xBA];
         let result = AtModemManager::decode_bcd_phone(&bytes, 2);
         assert_eq!(result, "*#");
+    }
+
+    #[test]
+    fn test_usbfs_node_path_zero_pads() {
+        assert_eq!(AtModemManager::usbfs_node_path(3, 7), "/dev/bus/usb/003/007");
+        assert_eq!(
+            AtModemManager::usbfs_node_path(1, 120),
+            "/dev/bus/usb/001/120"
+        );
+        assert_eq!(
+            AtModemManager::usbfs_node_path(255, 255),
+            "/dev/bus/usb/255/255"
+        );
     }
 
     #[test]

--- a/orange-pi-daemon/src/at_modem.rs
+++ b/orange-pi-daemon/src/at_modem.rs
@@ -8,9 +8,10 @@
 
 use anyhow::{anyhow, Result};
 use nix::sys::termios::{self, BaudRate, SetArg};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
+use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -110,72 +111,113 @@ impl AtModemManager {
 
     /// Discover all Quectel EC20 AT command ports
     /// EC20 uses ttyUSB2 for AT commands (every 4th port starting at 2)
-    /// Enumerate candidate AT-command ports present in /dev.
-    /// EC20/EC25 pattern: each modem exposes 4 ttyUSB ports and the AT port is the
-    /// 3rd (offset 2), so AT ports are ttyUSB2, ttyUSB6, ttyUSB10, … (num % 4 == 2).
-    pub fn candidate_at_ports() -> Result<Vec<String>> {
-        let mut at_ports: Vec<String> = fs::read_dir("/dev")
-            .map_err(|e| anyhow!("Failed to read /dev for modem discovery: {}", e))?
-            .filter_map(|entry| entry.ok())
-            .filter_map(|entry| {
-                let name = entry.file_name();
-                let name = name.to_string_lossy();
-                if !name.starts_with("ttyUSB") {
-                    return None;
+    /// Group every /dev/ttyUSB* port by the physical USB device (modem) that owns it.
+    ///
+    /// Each ttyUSB hangs off a USB interface dir like `.../1-1.3.2.2.3:1.0`; the USB
+    /// device is the parent (`1-1.3.2.2.3`). Returns device-path -> sorted port list.
+    /// This makes discovery independent of how many interfaces a modem exposes — works
+    /// for the default 4-port composition (AT at offset 2) and slimmed compositions
+    /// (e.g. AT at offset 0) alike.
+    pub fn ttyusb_by_usb_device() -> Result<BTreeMap<String, Vec<String>>> {
+        let mut groups: BTreeMap<String, Vec<u32>> = BTreeMap::new();
+        let entries = fs::read_dir("/sys/class/tty")
+            .map_err(|e| anyhow!("Failed to read /sys/class/tty: {}", e))?;
+        for entry in entries.filter_map(|e| e.ok()) {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !name.starts_with("ttyUSB") {
+                continue;
+            }
+            let Ok(num) = name.trim_start_matches("ttyUSB").parse::<u32>() else {
+                continue;
+            };
+            // The `device` link canonicalizes to the tty dir itself, nested under the
+            // USB interface dir (e.g. .../3-1.2.2:1.2/ttyUSB2). The physical modem is the
+            // ancestor USB *device* dir — the first one that carries an idVendor file
+            // (interfaces and the tty dir do not). Walk up to it and group by its name.
+            let link = format!("/sys/class/tty/{}/device", name);
+            let Ok(canon) = fs::canonicalize(&link) else {
+                continue;
+            };
+            let mut dir = canon.as_path();
+            let usb_dev = loop {
+                if dir.join("idVendor").is_file() {
+                    break dir.file_name().map(|f| f.to_string_lossy().into_owned());
                 }
-                let num = name.trim_start_matches("ttyUSB").parse::<u32>().ok()?;
-                if num >= 2 && num % 4 == 2 {
-                    Some(format!("/dev/ttyUSB{}", num))
-                } else {
-                    None
+                match dir.parent() {
+                    Some(p) if p.starts_with("/sys") && p != dir => dir = p,
+                    _ => break None,
                 }
+            };
+            let Some(usb_dev) = usb_dev else {
+                continue;
+            };
+            groups.entry(usb_dev).or_default().push(num);
+        }
+        Ok(groups
+            .into_iter()
+            .map(|(dev, mut nums)| {
+                nums.sort_unstable();
+                (dev, nums.into_iter().map(|n| format!("/dev/ttyUSB{}", n)).collect())
             })
-            .collect();
-        at_ports.sort();
-        Ok(at_ports)
+            .collect())
     }
 
-    /// Discover all Quectel AT command ports that currently respond to AT.
+    /// Order a modem's ttyUSB ports so the real AT command port is tried first.
+    ///
+    /// EC20 compositions place the AT port at a known slot: the default 4-port layout
+    /// is DIAG/NMEA/AT/MODEM → AT is the 3rd port (index 2); the slimmed AT+MODEM
+    /// layout has AT first (index 0). Several ports answer a bare "AT" (notably the
+    /// MODEM/PPP port), so we must try the AT slot first rather than the lowest port —
+    /// otherwise we may cache the PPP port and time out on real reads.
+    pub fn at_probe_order(ports: &[String]) -> Vec<String> {
+        let mut order: Vec<String> = Vec::with_capacity(ports.len());
+        if ports.len() >= 3 {
+            order.push(ports[2].clone()); // default 4-port: AT is index 2
+        }
+        for (i, p) in ports.iter().enumerate() {
+            if !(ports.len() >= 3 && i == 2) {
+                order.push(p.clone()); // index 0 first for slimmed, then the rest
+            }
+        }
+        order
+    }
+
+    /// Discover all modems by probing one AT port per physical USB device.
+    /// The AT slot is tried first (see `at_probe_order`); we keep the first port that
+    /// answers AT, so this works for both default 4-port and slimmed 2-port modems.
     pub async fn discover_modems(&self) -> Result<Vec<String>> {
+        let groups = Self::ttyusb_by_usb_device()?;
+        let device_count = groups.len();
         let mut ports = Vec::new();
-        let mut probe_failed_count = 0;
 
-        let at_ports = Self::candidate_at_ports()?;
-        let existing_count = at_ports.len();
-
-        for port_path in at_ports {
-            // Quick probe to verify it responds to AT
-            match self.probe_port_with_error(&port_path).await {
-                Ok(true) => {
-                    // Initialize IMS on successful probe
-                    if let Err(e) = self.init_ims(&port_path).await {
-                        warn!("Failed to initialize IMS on {}: {}", port_path, e);
+        for (_dev, dev_ports) in &groups {
+            for port_path in Self::at_probe_order(dev_ports) {
+                match self.probe_port_with_error(&port_path).await {
+                    Ok(true) => {
+                        if let Err(e) = self.init_ims(&port_path).await {
+                            warn!("Failed to initialize IMS on {}: {}", port_path, e);
+                        }
+                        ports.push(port_path);
+                        break; // one AT port per physical modem
                     }
-                    ports.push(port_path);
-                }
-                Ok(false) => {
-                    debug!("Port {} exists but no AT response", port_path);
-                    probe_failed_count += 1;
-                }
-                Err(e) => {
-                    warn!("Port {} probe error: {}", port_path, e);
-                    probe_failed_count += 1;
+                    Ok(false) => debug!("Port {} no AT response", port_path),
+                    Err(e) => debug!("Port {} probe error: {}", port_path, e),
                 }
             }
         }
 
-        if existing_count > 0 && ports.is_empty() {
+        if device_count > 0 && ports.is_empty() {
             warn!(
-                "Found {} USB serial ports but none responded to AT commands (probe failures: {})",
-                existing_count, probe_failed_count
+                "Found {} USB modem devices but none answered AT — check /dev/ttyUSB* permissions or port contention",
+                device_count
             );
-            warn!("Check: 1) permissions on /dev/ttyUSB*, 2) if ModemManager is holding ports");
         }
 
         info!(
-            "Discovered {} AT modem ports (scanned {} existing ports)",
+            "Discovered {} modems (scanned {} USB devices)",
             ports.len(),
-            existing_count
+            device_count
         );
         Ok(ports)
     }
@@ -315,15 +357,30 @@ impl AtModemManager {
         let port_path = port.to_string();
         let cmd = command.to_string();
 
-        // Run blocking serial I/O in spawn_blocking
-        tokio::task::spawn_blocking(move || Self::send_at_sync(&port_path, &cmd, timeout)).await?
+        // Run blocking serial I/O in spawn_blocking, but cap it at the async layer with
+        // a hard deadline. A wedged modem can block a tty ioctl (tcgetattr/tcflush) —
+        // O_NONBLOCK only covers read/write, not ioctls — which would otherwise hang the
+        // task forever. If the deadline fires we abandon the (leaked) blocking thread and
+        // report failure, so discovery/reads skip the bad port instead of stalling.
+        let handle =
+            tokio::task::spawn_blocking(move || Self::send_at_sync(&port_path, &cmd, timeout));
+        match tokio::time::timeout(timeout + Duration::from_secs(2), handle).await {
+            Ok(joined) => joined?,
+            Err(_) => Err(anyhow!("AT command timed out (port may be wedged): {}", port)),
+        }
     }
 
     /// Open serial port with proper settings
     fn open_serial(port: &str) -> Result<File> {
+        // Open and KEEP the port non-blocking. A blocking serial open() waits for
+        // carrier (DCD); a wedged modem never asserts it, hanging the thread forever.
+        // Keeping O_NONBLOCK set also makes read()/write() return WouldBlock instead
+        // of blocking, so a wedged port can never stall us — send_at_sync polls both
+        // with a hard timeout. O_NOCTTY keeps the tty from becoming our controlling tty.
         let file = OpenOptions::new()
             .read(true)
             .write(true)
+            .custom_flags(nix::libc::O_NONBLOCK | nix::libc::O_NOCTTY)
             .open(port)
             .map_err(|e| anyhow!("Failed to open {}: {}", port, e))?;
 
@@ -373,20 +430,35 @@ impl AtModemManager {
         Ok(file)
     }
 
-    /// Synchronous AT command send (runs in blocking thread)
+    /// Synchronous AT command send (runs in blocking thread).
+    /// The fd is non-blocking, so writes/reads return WouldBlock rather than hanging on
+    /// a wedged modem; we poll both with the same hard timeout.
     fn send_at_sync(port: &str, command: &str, timeout: Duration) -> Result<String> {
         let mut file = Self::open_serial(port)?;
+        let start = Instant::now();
 
-        // Send command with CR
+        // Send command with CR. Non-blocking write may report WouldBlock; retry until
+        // the buffer accepts it or we hit the timeout.
         let cmd = format!("{}\r", command);
-        file.write_all(cmd.as_bytes())
-            .map_err(|e| anyhow!("Write failed: {}", e))?;
-        file.flush()?;
+        let mut written = 0;
+        while written < cmd.len() {
+            if start.elapsed() > timeout {
+                return Err(anyhow!("Write timeout on {}", port));
+            }
+            match file.write(&cmd.as_bytes()[written..]) {
+                Ok(0) => std::thread::sleep(Duration::from_millis(10)),
+                Ok(n) => written += n,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(10))
+                }
+                Err(e) => return Err(anyhow!("Write failed: {}", e)),
+            }
+        }
+        let _ = file.flush();
 
         // Read response with timeout
         let mut response = Vec::new();
         let mut buf = [0u8; 256];
-        let start = Instant::now();
 
         loop {
             if start.elapsed() > timeout {
@@ -1569,21 +1641,21 @@ impl AtModemManager {
         Ok(info)
     }
 
-    /// Convert port path to modem ID
-    /// /dev/ttyUSB2 -> "0", /dev/ttyUSB6 -> "1", etc.
+    /// Convert AT-port path to modem ID.
+    /// The modem ID is simply the AT port's ttyUSB index ("/dev/ttyUSB6" -> "6").
+    /// This is independent of USB composition (no fixed 4-ports-per-modem assumption),
+    /// so it works for both default and slimmed modems. The ID is an internal handle;
+    /// the stable cross-system key is the modem's IMEI (equipment_id).
     pub fn port_to_modem_id(port: &str) -> String {
-        if let Some(num_str) = port.strip_prefix("/dev/ttyUSB") {
-            if let Ok(num) = num_str.parse::<u32>() {
-                return ((num - 2) / 4).to_string();
-            }
-        }
-        port.to_string()
+        port.strip_prefix("/dev/ttyUSB")
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| port.to_string())
     }
 
-    /// Convert modem ID to port path
+    /// Convert modem ID back to its AT port path ("6" -> "/dev/ttyUSB6").
     pub fn modem_id_to_port(id: &str) -> String {
-        if let Ok(num) = id.parse::<u32>() {
-            return format!("/dev/ttyUSB{}", num * 4 + 2);
+        if id.parse::<u32>().is_ok() {
+            return format!("/dev/ttyUSB{}", id);
         }
         id.to_string()
     }
@@ -2009,6 +2081,46 @@ mod tests {
         let bytes = vec![0xBA];
         let result = AtModemManager::decode_bcd_phone(&bytes, 2);
         assert_eq!(result, "*#");
+    }
+
+    #[test]
+    fn test_at_probe_order() {
+        let p4: Vec<String> = (0..4).map(|n| format!("/dev/ttyUSB{}", n)).collect();
+        // 4-port: AT slot (index 2) tried first, then 0,1,3
+        assert_eq!(
+            AtModemManager::at_probe_order(&p4),
+            vec![
+                "/dev/ttyUSB2",
+                "/dev/ttyUSB0",
+                "/dev/ttyUSB1",
+                "/dev/ttyUSB3"
+            ]
+        );
+        // 2-port (slimmed): index 0 first
+        let p2: Vec<String> = vec!["/dev/ttyUSB6".into(), "/dev/ttyUSB7".into()];
+        assert_eq!(
+            AtModemManager::at_probe_order(&p2),
+            vec!["/dev/ttyUSB6", "/dev/ttyUSB7"]
+        );
+        // single port
+        let p1: Vec<String> = vec!["/dev/ttyUSB9".into()];
+        assert_eq!(AtModemManager::at_probe_order(&p1), vec!["/dev/ttyUSB9"]);
+    }
+
+    #[test]
+    fn test_modem_id_port_roundtrip() {
+        // modem_id is the AT port's ttyUSB index — works for any offset (default or slimmed)
+        assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB2"), "2");
+        assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB0"), "0");
+        assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB58"), "58");
+        assert_eq!(AtModemManager::modem_id_to_port("2"), "/dev/ttyUSB2");
+        assert_eq!(AtModemManager::modem_id_to_port("0"), "/dev/ttyUSB0");
+        assert_eq!(AtModemManager::modem_id_to_port("58"), "/dev/ttyUSB58");
+        // round-trip
+        for n in ["0", "1", "2", "6", "57", "240"] {
+            let port = AtModemManager::modem_id_to_port(n);
+            assert_eq!(AtModemManager::port_to_modem_id(&port), n);
+        }
     }
 
     #[test]

--- a/orange-pi-daemon/src/main.rs
+++ b/orange-pi-daemon/src/main.rs
@@ -224,6 +224,10 @@ async fn main() -> Result<()> {
 
     let modem_ids: Vec<String> = valid_modems.keys().cloned().collect();
 
+    // Live modem set, shared and mutable: the reader loop reads it each tick and the
+    // re-discovery task (Task 7) appends modems that appear or recover after startup.
+    let modem_set: Arc<RwLock<Vec<String>>> = Arc::new(RwLock::new(modem_ids.clone()));
+
     // Notify systemd that we're ready
     let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
     info!("🔔 Notified systemd - daemon is ready");
@@ -243,18 +247,18 @@ async fn main() -> Result<()> {
     let modem_reader_store = message_store.clone();
     let modem_reader_manager = modem_manager.clone();
     let modem_reader_pool = worker_pool.clone();
-    let modem_reader_ids = modem_ids.clone();
+    let modem_reader_set = modem_set.clone();
     let reader_devices = latest_devices.clone();
 
     tokio::spawn(async move {
         loop {
             let start = Instant::now();
 
+            // Snapshot the current live modem set (Task 7 may have grown it).
+            let current_ids = modem_reader_set.read().await.clone();
+
             // Read from all modems in parallel
-            match modem_reader_pool
-                .process_modems(modem_reader_ids.clone())
-                .await
-            {
+            match modem_reader_pool.process_modems(current_ids).await {
                 Ok(results) => {
                     // Collect modem reports for the device sync task
                     let mut reports = Vec::new();
@@ -582,6 +586,42 @@ async fn main() -> Result<()> {
 
             // Poll every 10 seconds for pending SMS
             tokio::time::sleep(Duration::from_secs(10)).await;
+        }
+    });
+
+    // TASK 7: DYNAMIC MODEM RE-DISCOVERY (every 60 seconds)
+    // Picks up modems that enumerate after startup and actively USB-resets wedged ones
+    // (present ttyUSB but silent on AT), merging any newly-found modems into the live
+    // set with no daemon restart. Cannot recover modems that never enumerate a ttyUSB
+    // (steady-state USB power/topology failures) — those need a hardware fix.
+    let rediscover_manager = modem_manager.clone();
+    let rediscover_set = modem_set.clone();
+
+    tokio::spawn(async move {
+        info!("🔎 Modem re-discovery task started - scanning every 60 seconds");
+        loop {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+
+            let known: std::collections::HashSet<String> =
+                rediscover_set.read().await.iter().cloned().collect();
+
+            match rediscover_manager.rediscover_and_merge(&known).await {
+                Ok(added) if !added.is_empty() => {
+                    let mut set = rediscover_set.write().await;
+                    for id in &added {
+                        if !set.contains(id) {
+                            set.push(id.clone());
+                        }
+                    }
+                    info!(
+                        "🔎 Re-discovery: added {} new modem(s), now {} total",
+                        added.len(),
+                        set.len()
+                    );
+                }
+                Ok(_) => debug!("🔎 Re-discovery: no new modems"),
+                Err(e) => warn!("🔎 Re-discovery failed: {}", e),
+            }
         }
     });
 

--- a/orange-pi-daemon/src/modem_manager.rs
+++ b/orange-pi-daemon/src/modem_manager.rs
@@ -125,6 +125,77 @@ impl ModemManager {
         }
     }
 
+    /// Find modems that are NOT already active and bring them online, merging them into
+    /// the port cache. For a candidate AT port that is silent, attempt one USB reset +
+    /// re-probe (recovers modems wedged at the USB level). Returns the modem_ids added.
+    ///
+    /// Deliberately skips modems already in `known` or the cache: re-probing a healthy,
+    /// busy modem could collide with the reader loop on the serial port and trigger a
+    /// needless reset. The serial probes/resets run WITHOUT holding the cache lock so
+    /// the reader's `get_port` is never blocked; the lock is taken only to insert.
+    ///
+    /// AT-command mode only; in D-Bus mode ModemManager handles its own hotplug.
+    pub async fn rediscover_and_merge(
+        &self,
+        known: &std::collections::HashSet<String>,
+    ) -> Result<Vec<String>> {
+        if self.mode != BackendMode::AtCommand {
+            return Ok(Vec::new());
+        }
+
+        // Snapshot the set of modems already accounted for (caller's live set + cache).
+        let active: std::collections::HashSet<String> = {
+            let cache = self.port_cache.read().await;
+            known.iter().cloned().chain(cache.keys().cloned()).collect()
+        };
+
+        // Probe/reset only NON-active candidates, holding no lock.
+        let mut found: Vec<(String, String)> = Vec::new();
+        let mut reset_recovered = 0;
+        for port in AtModemManager::candidate_at_ports()? {
+            let id = AtModemManager::port_to_modem_id(&port);
+            if active.contains(&id) {
+                continue;
+            }
+            let responsive = if self.at_modem.probe_port(&port).await {
+                true
+            } else {
+                match self.at_modem.reset_usb_port(&port).await {
+                    Ok(true) => {
+                        reset_recovered += 1;
+                        true
+                    }
+                    Ok(false) => false,
+                    Err(e) => {
+                        debug!("Cannot reset {}: {}", port, e);
+                        false
+                    }
+                }
+            };
+            if responsive {
+                let _ = self.at_modem.init_ims(&port).await;
+                found.push((id, port));
+            }
+        }
+
+        if found.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut cache = self.port_cache.write().await;
+        let mut added = Vec::new();
+        for (id, port) in found {
+            if !cache.contains_key(&id) {
+                added.push(id.clone());
+            }
+            cache.insert(id, port);
+        }
+        if reset_recovered > 0 {
+            info!("Recovered {} wedged modem(s) via USB reset", reset_recovered);
+        }
+        Ok(added)
+    }
+
     /// Get port for modem ID
     async fn get_port(&self, modem_id: &str) -> String {
         if let Some(port) = self.port_cache.read().await.get(modem_id) {

--- a/orange-pi-daemon/src/modem_manager.rs
+++ b/orange-pi-daemon/src/modem_manager.rs
@@ -143,38 +143,55 @@ impl ModemManager {
             return Ok(Vec::new());
         }
 
-        // Snapshot the set of modems already accounted for (caller's live set + cache).
-        let active: std::collections::HashSet<String> = {
+        // Snapshot ports already served (so we skip whole devices that are working).
+        let active_ports: std::collections::HashSet<String> = {
             let cache = self.port_cache.read().await;
-            known.iter().cloned().chain(cache.keys().cloned()).collect()
+            cache.values().cloned().collect()
         };
 
-        // Probe/reset only NON-active candidates, holding no lock.
+        // Walk each physical modem (USB device); skip ones that already have a working
+        // port. For the rest, probe ports in order to find AT; if all are silent, try a
+        // USB reset on the first port then re-probe. Holds no lock during serial I/O.
         let mut found: Vec<(String, String)> = Vec::new();
         let mut reset_recovered = 0;
-        for port in AtModemManager::candidate_at_ports()? {
-            let id = AtModemManager::port_to_modem_id(&port);
-            if active.contains(&id) {
-                continue;
+        for (_dev, dev_ports) in AtModemManager::ttyusb_by_usb_device()? {
+            if dev_ports.iter().any(|p| active_ports.contains(p)) {
+                continue; // this modem is already online — don't touch it
             }
-            let responsive = if self.at_modem.probe_port(&port).await {
-                true
-            } else {
-                match self.at_modem.reset_usb_port(&port).await {
-                    Ok(true) => {
-                        reset_recovered += 1;
-                        true
-                    }
-                    Ok(false) => false,
-                    Err(e) => {
-                        debug!("Cannot reset {}: {}", port, e);
-                        false
+
+            let probe_order = AtModemManager::at_probe_order(&dev_ports);
+            let mut at_port: Option<String> = None;
+            for p in &probe_order {
+                if self.at_modem.probe_port(p).await {
+                    at_port = Some(p.clone());
+                    break;
+                }
+            }
+            // All ports silent — attempt a USB reset on the first port, then re-probe.
+            if at_port.is_none() {
+                if let Some(first) = dev_ports.first() {
+                    match self.at_modem.reset_usb_port(first).await {
+                        Ok(true) => {
+                            reset_recovered += 1;
+                            for p in &probe_order {
+                                if self.at_modem.probe_port(p).await {
+                                    at_port = Some(p.clone());
+                                    break;
+                                }
+                            }
+                        }
+                        Ok(false) => {}
+                        Err(e) => debug!("Cannot reset {}: {}", first, e),
                     }
                 }
-            };
-            if responsive {
-                let _ = self.at_modem.init_ims(&port).await;
-                found.push((id, port));
+            }
+
+            if let Some(port) = at_port {
+                let id = AtModemManager::port_to_modem_id(&port);
+                if !known.contains(&id) {
+                    let _ = self.at_modem.init_ims(&port).await;
+                    found.push((id, port));
+                }
             }
         }
 

--- a/orange-pi-daemon/tests/at_modem_tests.rs
+++ b/orange-pi-daemon/tests/at_modem_tests.rs
@@ -8,27 +8,27 @@ use orange_pi_daemon_rust::at_modem::{AtModemManager, AtModemInfo, ModemHealth};
 
 #[test]
 fn test_port_conversion() {
-    // Test modem_id <-> port conversion (public static methods)
-    assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB2"), "0");
-    assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB6"), "1");
-    assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB10"), "2");
-    assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB50"), "12");
+    // modem_id is now the AT port's ttyUSB index (no fixed 4-ports-per-modem math),
+    // so discovery works for both default (AT@offset2) and slimmed (AT@offset0) modems.
+    assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB2"), "2");
+    assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB6"), "6");
+    assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB10"), "10");
+    assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB0"), "0");
 
-    assert_eq!(AtModemManager::modem_id_to_port("0"), "/dev/ttyUSB2");
-    assert_eq!(AtModemManager::modem_id_to_port("1"), "/dev/ttyUSB6");
-    assert_eq!(AtModemManager::modem_id_to_port("2"), "/dev/ttyUSB10");
-    assert_eq!(AtModemManager::modem_id_to_port("12"), "/dev/ttyUSB50");
+    assert_eq!(AtModemManager::modem_id_to_port("2"), "/dev/ttyUSB2");
+    assert_eq!(AtModemManager::modem_id_to_port("6"), "/dev/ttyUSB6");
+    assert_eq!(AtModemManager::modem_id_to_port("10"), "/dev/ttyUSB10");
+    assert_eq!(AtModemManager::modem_id_to_port("0"), "/dev/ttyUSB0");
 }
 
 #[test]
 fn test_port_conversion_boundary_cases() {
-    // Test valid boundary cases (avoid invalid inputs that cause panics)
-    assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB2"), "0");
-    assert_eq!(AtModemManager::port_to_modem_id("/dev/ttyUSB102"), "25");
-
-    assert_eq!(AtModemManager::modem_id_to_port("0"), "/dev/ttyUSB2");
-    assert_eq!(AtModemManager::modem_id_to_port("25"), "/dev/ttyUSB102");
-    assert_eq!(AtModemManager::modem_id_to_port("99"), "/dev/ttyUSB398");
+    // Round-trips across the full range, including offset-0 (slimmed) ports.
+    for n in ["0", "1", "2", "6", "25", "102", "240"] {
+        let port = AtModemManager::modem_id_to_port(n);
+        assert_eq!(port, format!("/dev/ttyUSB{}", n));
+        assert_eq!(AtModemManager::port_to_modem_id(&port), n);
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Repairs the build after a `nix flake update` and substantially hardens the Orange Pi SMS daemon. All changes are deployed and running in production (reading ~57 modems at 100%, surviving repeated power-cycles/replugging with zero hangs).

### Nix / system
- Fix devShell + Orange Pi config after the nixpkgs bump removed `nodePackages`, flagged `nodejs_20` insecure, and removed `linuxPackages_hardened` → use `linuxPackages_latest`.
- Add `usbcore.old_scheme_first=1` kernel param (helps marginal modems enumerate).

### Daemon robustness
- **Boot-race fix**: `preStart` waits for USB enumeration to settle before start (no more cache frozen at a low count after reboot).
- **Dynamic re-discovery (Task 7)**: picks up modems that appear/recover after startup; merges into a live shared set with no restart.
- **Active USB reset**: `USBDEVFS_RESET` on wedged modems (udev rule grants the daemon access to the Quectel usbfs nodes).
- **Per-device discovery**: groups ttyUSB by physical USB device and probes one AT port per modem — works for both default 4-port and slimmed 2-port compositions (replaces the fixed `n%4==2` assumption).
- **Non-blocking, time-bounded serial I/O**: `O_NONBLOCK|O_NOCTTY` open + non-blocking write + a tokio deadline around the blocking op. A wedged modem (which can block even a tty ioctl) now times out and is skipped instead of hanging the whole daemon. *This was the root cause of several outages during testing and is now fixed.*

### Ops
- `scripts/slim-modem-usbcfg.sh`: reduce each EC20's USB composition from 5 interfaces to AT+MODEM to cut endpoint/bandwidth footprint (verified per-modem).

## Testing
- 77 unit + integration tests pass.
- Deployed to the Orange Pi; verified discovery completes cleanly (59-62 modems, 0 timeouts, ~3.5s cycles) and the daemon never hangs across power-cycles, reboots, and heavy replugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)